### PR TITLE
fix: don't stop executing init.ts after sucking data if user also wants to seed

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -278,7 +278,7 @@ async function run() {
 				const isDone = await suckDay(day, year);
 				if (isDone) {
 					console.log(`Finished sucking year ${year} after day: ${day - 1}.`);
-					return;
+					break;
 				}
 
 				// Wait 100ms between requests, because idk.


### PR DESCRIPTION
Very quick and simple fix.  In init.ts on line 280, the code that sucks data from the Advent of Code website, if the code has sucessfully sucked in the data for any given day, you `return`, which stops execution of init.ts entirely. This breaks the command you listed in the readme to get up and running, `npx ts-node init suck seed` because the code no longer gets to the seeding step.

Made it a `break` instead to break out of the for loop, which seems to result in the intended behaviour.